### PR TITLE
Fix #237: advancements granted without ever catching an RLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
  - - Dragon Axe : Power 90 Precision 100 PP 5 - The user attacks with a fierce dragon-like slice. This also lowers the user's Defense stat.
 - Fennekin RLM Added
 - Braixen RLM : texture has reworked
+- Advancements fixed : they were all granted on the first Pokémon caught, without ever catching an RLM (#237)

--- a/data/cobblemonrlm/advancement/catch_fakemon.json
+++ b/data/cobblemonrlm/advancement/catch_fakemon.json
@@ -25,72 +25,169 @@
         "sound": "minecraft:ui.toast.challenge_complete"
     },
     "criteria": {
-        "flammiko": {
+        "flammiko_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:flammiko"
+                "species": "cobblemon:flammiko",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "kotora": {
+        "flammiko_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:kotora"
+                "species": "cobblemon:flammiko",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "rineshell": {
+        "kotora_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:rineshell"
+                "species": "cobblemon:kotora",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "galama": {
+        "kotora_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:galama"
+                "species": "cobblemon:kotora",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "apheos": {
+        "rineshell_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:apheos"
+                "species": "cobblemon:rineshell",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "aphelis": {
+        "rineshell_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:aphelis"
+                "species": "cobblemon:rineshell",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "tinywone": {
+        "galama_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:tinywone"
+                "species": "cobblemon:galama",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "wamek": {
+        "galama_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:wamek"
+                "species": "cobblemon:galama",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "smowile": {
+        "apheos_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:smowile"
+                "species": "cobblemon:apheos",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "apheos_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:apheos",
+                "aspects": [
+                    "female"
+                ]
+            }
+        },
+        "aphelis_male": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:aphelis",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "aphelis_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:aphelis",
+                "aspects": [
+                    "female"
+                ]
+            }
+        },
+        "tinywone_genderless": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:tinywone",
+                "aspects": [
+                    "genderless"
+                ]
+            }
+        },
+        "wamek_genderless": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:wamek",
+                "aspects": [
+                    "genderless"
+                ]
+            }
+        },
+        "smowile_male": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "smowile_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "female"
+                ]
             }
         }
     },
     "requirements": [
         [
-            "flammiko",
-            "kotora",
-            "rineshell",
-            "galama",
-            "apheos",
-            "aphelis",
-            "tinywone",
-            "wamek",
-            "smowile"
+            "flammiko_male",
+            "flammiko_female",
+            "kotora_male",
+            "kotora_female",
+            "rineshell_male",
+            "rineshell_female",
+            "galama_male",
+            "galama_female",
+            "apheos_male",
+            "apheos_female",
+            "aphelis_male",
+            "aphelis_female",
+            "tinywone_genderless",
+            "wamek_genderless",
+            "smowile_male",
+            "smowile_female"
         ]
     ]
 }

--- a/data/cobblemonrlm/advancement/catch_mawile_family.json
+++ b/data/cobblemonrlm/advancement/catch_mawile_family.json
@@ -25,10 +25,22 @@
         "sound": "minecraft:ui.toast.challenge_complete"
     },
     "criteria": {
-        "smowile": {
+        "smowile_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:smowile"
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "smowile_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "female"
+                ]
             }
         },
         "poison": {
@@ -52,7 +64,8 @@
     },
     "requirements": [
         [
-            "smowile"
+            "smowile_male",
+            "smowile_female"
         ],
         [
             "poison"

--- a/data/cobblemonrlm/advancement/catch_rlm.json
+++ b/data/cobblemonrlm/advancement/catch_rlm.json
@@ -25,10 +25,244 @@
         "sound": "minecraft:ui.toast.challenge_complete"
     },
     "criteria": {
-        "catch_any_rlm": {
-            "trigger": "cobblemon:catch_pokemon",
+        "meganium": {
+            "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "count": 1,
+                "species": "cobblemon:meganium",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "bayleef": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:bayleef",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "blastoise": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:blastoise",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "wartortle": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:wartortle",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "empoleon": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:empoleon",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "prinplup": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:prinplup",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "delphox": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:delphox",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "braixen": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:braixen",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "fennekin": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:fennekin",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "togekiss": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:togekiss",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "probopass": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:probopass",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "nosepass": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:nosepass",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "luxray": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:luxray",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "luxio": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:luxio",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "shinx": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:shinx",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "ampharos": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:ampharos",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "flaaffy": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:flaaffy",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "mareep": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:mareep",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "spiritomb": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:spiritomb",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "ninjask": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:ninjask",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "shedinja": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:shedinja",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "nincada": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:nincada",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "sunflora": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:sunflora",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "mawile": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:mawile",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "haxorus": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:haxorus",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "fraxure": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:fraxure",
+                "aspects": [
+                    "rlm"
+                ]
+            }
+        },
+        "axew": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:axew",
                 "aspects": [
                     "rlm"
                 ]
@@ -37,7 +271,33 @@
     },
     "requirements": [
         [
-            "catch_any_rlm"
+            "meganium",
+            "bayleef",
+            "blastoise",
+            "wartortle",
+            "empoleon",
+            "prinplup",
+            "delphox",
+            "braixen",
+            "fennekin",
+            "togekiss",
+            "probopass",
+            "nosepass",
+            "luxray",
+            "luxio",
+            "shinx",
+            "ampharos",
+            "flaaffy",
+            "mareep",
+            "spiritomb",
+            "ninjask",
+            "shedinja",
+            "nincada",
+            "sunflora",
+            "mawile",
+            "haxorus",
+            "fraxure",
+            "axew"
         ]
     ]
 }

--- a/data/cobblemonrlm/advancement/catch_rlm_shiny.json
+++ b/data/cobblemonrlm/advancement/catch_rlm_shiny.json
@@ -26,19 +26,306 @@
         "sound": "minecraft:ui.toast.challenge_complete"
     },
     "criteria": {
-        "catch_any_shiny_rlm": {
-            "trigger": "cobblemon:catch_shiny_pokemon",
+        "meganium": {
+            "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "count": 1,
+                "species": "cobblemon:meganium",
                 "aspects": [
-                    "rlm"
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "bayleef": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:bayleef",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "blastoise": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:blastoise",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "wartortle": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:wartortle",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "empoleon": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:empoleon",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "prinplup": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:prinplup",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "delphox": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:delphox",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "braixen": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:braixen",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "fennekin": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:fennekin",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "togekiss": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:togekiss",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "probopass": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:probopass",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "nosepass": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:nosepass",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "luxray": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:luxray",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "luxio": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:luxio",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "shinx": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:shinx",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "ampharos": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:ampharos",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "flaaffy": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:flaaffy",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "mareep": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:mareep",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "spiritomb": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:spiritomb",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "ninjask": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:ninjask",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "shedinja": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:shedinja",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "nincada": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:nincada",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "sunflora": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:sunflora",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "mawile": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:mawile",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "haxorus": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:haxorus",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "fraxure": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:fraxure",
+                "aspects": [
+                    "rlm",
+                    "shiny"
+                ]
+            }
+        },
+        "axew": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:axew",
+                "aspects": [
+                    "rlm",
+                    "shiny"
                 ]
             }
         }
     },
     "requirements": [
         [
-            "catch_any_shiny_rlm"
+            "meganium",
+            "bayleef",
+            "blastoise",
+            "wartortle",
+            "empoleon",
+            "prinplup",
+            "delphox",
+            "braixen",
+            "fennekin",
+            "togekiss",
+            "probopass",
+            "nosepass",
+            "luxray",
+            "luxio",
+            "shinx",
+            "ampharos",
+            "flaaffy",
+            "mareep",
+            "spiritomb",
+            "ninjask",
+            "shedinja",
+            "nincada",
+            "sunflora",
+            "mawile",
+            "haxorus",
+            "fraxure",
+            "axew"
         ]
     ]
 }

--- a/data/cobblemonrlm/advancement/complete_fakemon_dex.json
+++ b/data/cobblemonrlm/advancement/complete_fakemon_dex.json
@@ -25,88 +25,185 @@
         "sound": "minecraft:ui.toast.challenge_complete"
     },
     "criteria": {
-        "flammiko": {
+        "flammiko_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:flammiko"
+                "species": "cobblemon:flammiko",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "kotora": {
+        "flammiko_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:kotora"
+                "species": "cobblemon:flammiko",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "rineshell": {
+        "kotora_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:rineshell"
+                "species": "cobblemon:kotora",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "galama": {
+        "kotora_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:galama"
+                "species": "cobblemon:kotora",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "apheos": {
+        "rineshell_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:apheos"
+                "species": "cobblemon:rineshell",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "aphelis": {
+        "rineshell_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:aphelis"
+                "species": "cobblemon:rineshell",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "tinywone": {
+        "galama_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:tinywone"
+                "species": "cobblemon:galama",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "wamek": {
+        "galama_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:wamek"
+                "species": "cobblemon:galama",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "smowile": {
+        "apheos_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:smowile"
+                "species": "cobblemon:apheos",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "apheos_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:apheos",
+                "aspects": [
+                    "female"
+                ]
+            }
+        },
+        "aphelis_male": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:aphelis",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "aphelis_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:aphelis",
+                "aspects": [
+                    "female"
+                ]
+            }
+        },
+        "tinywone_genderless": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:tinywone",
+                "aspects": [
+                    "genderless"
+                ]
+            }
+        },
+        "wamek_genderless": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:wamek",
+                "aspects": [
+                    "genderless"
+                ]
+            }
+        },
+        "smowile_male": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "smowile_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "female"
+                ]
             }
         }
     },
     "requirements": [
         [
-            "flammiko"
+            "flammiko_male",
+            "flammiko_female"
         ],
         [
-            "kotora"
+            "kotora_male",
+            "kotora_female"
         ],
         [
-            "rineshell"
+            "rineshell_male",
+            "rineshell_female"
         ],
         [
-            "galama"
+            "galama_male",
+            "galama_female"
         ],
         [
-            "apheos"
+            "apheos_male",
+            "apheos_female"
         ],
         [
-            "aphelis"
+            "aphelis_male",
+            "aphelis_female"
         ],
         [
-            "tinywone"
+            "tinywone_genderless"
         ],
         [
-            "wamek"
+            "wamek_genderless"
         ],
         [
-            "smowile"
+            "smowile_male",
+            "smowile_female"
         ]
     ]
 }

--- a/data/cobblemonrlm/advancement/complete_rlm_dex.json
+++ b/data/cobblemonrlm/advancement/complete_rlm_dex.json
@@ -172,58 +172,148 @@
                 ]
             }
         },
-        "flammiko": {
+        "flammiko_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:flammiko"
+                "species": "cobblemon:flammiko",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "kotora": {
+        "flammiko_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:kotora"
+                "species": "cobblemon:flammiko",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "rineshell": {
+        "kotora_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:rineshell"
+                "species": "cobblemon:kotora",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "galama": {
+        "kotora_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:galama"
+                "species": "cobblemon:kotora",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "apheos": {
+        "rineshell_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:apheos"
+                "species": "cobblemon:rineshell",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "aphelis": {
+        "rineshell_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:aphelis"
+                "species": "cobblemon:rineshell",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "tinywone": {
+        "galama_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:tinywone"
+                "species": "cobblemon:galama",
+                "aspects": [
+                    "male"
+                ]
             }
         },
-        "wamek": {
+        "galama_female": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:wamek"
+                "species": "cobblemon:galama",
+                "aspects": [
+                    "female"
+                ]
             }
         },
-        "smowile": {
+        "apheos_male": {
             "trigger": "cobblemon:aspects_collected",
             "conditions": {
-                "species": "cobblemon:smowile"
+                "species": "cobblemon:apheos",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "apheos_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:apheos",
+                "aspects": [
+                    "female"
+                ]
+            }
+        },
+        "aphelis_male": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:aphelis",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "aphelis_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:aphelis",
+                "aspects": [
+                    "female"
+                ]
+            }
+        },
+        "tinywone_genderless": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:tinywone",
+                "aspects": [
+                    "genderless"
+                ]
+            }
+        },
+        "wamek_genderless": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:wamek",
+                "aspects": [
+                    "genderless"
+                ]
+            }
+        },
+        "smowile_male": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "male"
+                ]
+            }
+        },
+        "smowile_female": {
+            "trigger": "cobblemon:aspects_collected",
+            "conditions": {
+                "species": "cobblemon:smowile",
+                "aspects": [
+                    "female"
+                ]
             }
         }
     },
@@ -277,31 +367,38 @@
             "mawile_dragon"
         ],
         [
-            "flammiko"
+            "flammiko_male",
+            "flammiko_female"
         ],
         [
-            "kotora"
+            "kotora_male",
+            "kotora_female"
         ],
         [
-            "rineshell"
+            "rineshell_male",
+            "rineshell_female"
         ],
         [
-            "galama"
+            "galama_male",
+            "galama_female"
         ],
         [
-            "apheos"
+            "apheos_male",
+            "apheos_female"
         ],
         [
-            "aphelis"
+            "aphelis_male",
+            "aphelis_female"
         ],
         [
-            "tinywone"
+            "tinywone_genderless"
         ],
         [
-            "wamek"
+            "wamek_genderless"
         ],
         [
-            "smowile"
+            "smowile_male",
+            "smowile_female"
         ]
     ]
 }


### PR DESCRIPTION
Three separate data errors caused every RLM advancement to unlock on the player's very first capture:

- catch_rlm used cobblemon:catch_pokemon with an "aspects" field. That trigger (CaughtPokemonCriterion) only understands "type" and "count", so the aspect filter was silently dropped and any catch matched.
- catch_rlm_shiny used cobblemon:catch_shiny_pokemon with "aspects". That trigger is a plain CountableCriterion (count only), so any shiny catch matched.
- The Fakemon criteria passed a species with no "aspects" list. AspectCriterion matches with `aspects.all { it in collected }`, which is vacuously true on an empty list, so they matched on any capture.

All of them now use cobblemon:aspects_collected with a non-empty aspect list. The RLM advancements enumerate every species that has an "rlm" form as an OR requirement group. The Fakemon have no distinguishing aspect of their own, so they key on the gender aspect, which every Pokemon always carries (genderless for Tinywone and Wamek).